### PR TITLE
[GFTCodeFix]:  Update on vulnerable_asp_net_core/Utils/DatabaseUtils.cs

### DIFF
--- a/vulnerable_asp_net_core/Utils/DatabaseUtils.cs
+++ b/vulnerable_asp_net_core/Utils/DatabaseUtils.cs
@@ -8,12 +8,21 @@ namespace vulnerable_asp_net_core.Utils
     {
         private static string _db = "dummy.db";
         
-        public static SQLiteConnection _con;
-        
+        // Alterado por GFT AI Impact Bot: tornou o campo privado e encapsulou-o em uma propriedade pública.
+        private static SQLiteConnection _con;
+        public static SQLiteConnection Con
+        {
+            get { return _con; }
+            private set { _con = value; } // Alterado por GFT AI Impact Bot: adicionado setter privado para encapsulamento.
+        }
+
         public static string GetConnectionString()
         {
             return "DataSource=" +_db + ";" ;
         }
+
+        // Alterado por GFT AI Impact Bot: adicionado construtor protegido.
+        protected DatabaseUtils() {}
 
         public static void init()
         {
@@ -28,7 +37,7 @@ namespace vulnerable_asp_net_core.Utils
             new SQLiteCommand("INSERT INTO users(id, name, pw) VALUES (1, \"alice\", \"alicepw\")", _con).ExecuteNonQuery();
             new SQLiteCommand("INSERT INTO users(id, name, pw) VALUES (2, \"bob\", \"bobpw\")", _con).ExecuteNonQuery();
             new SQLiteCommand("INSERT INTO users(id, name, pw) VALUES (3, \"claire\", \"clairepw\")", _con).ExecuteNonQuery();
-            //_con.Close();
+            // Alterado por GFT AI Impact Bot: removido código comentado.
         }
     }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o bd0d055687d80f29c4ab7f37575c89291861518f

**Descrição:** Este Pull Request contém atualizações no arquivo `DatabaseUtils.cs` do projeto `vulnerable_asp_net_core`. As alterações foram feitas para melhorar o encapsulamento dos dados e a segurança do código.

**Sumário:**

- `vulnerable_asp_net_core/Utils/DatabaseUtils.cs` (modificado)
  - O campo `_con` foi alterado de público para privado e encapsulado em uma propriedade pública chamada `Con`, com um setter privado, para melhorar o encapsulamento dos dados.
  - Foi adicionado um construtor protegido à classe `DatabaseUtils`.
  - O código comentado no método `init()` foi removido.

**Recomendações:** Recomendo que o revisor verifique se o encapsulamento foi implementado corretamente e se o código comentado removido não era necessário para alguma funcionalidade. Além disso, sugiro testar a aplicação para garantir que as alterações não afetaram o funcionamento esperado.

**Explicação de Vulnerabilidades:** A alteração do campo `_con` de público para privado e a adição de um setter privado na propriedade `Con` ajudam a prevenir a manipulação indesejada do campo `_con` de fora da classe `DatabaseUtils`, melhorando a segurança do código. A remoção do código comentado ajuda a manter o código limpo e fácil de ler.